### PR TITLE
Allow output to be specified as path

### DIFF
--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -103,6 +103,8 @@ if ($input_sniffles eq "" && $input_cutesv eq "" && $input_pbsv eq "" && $input_
     die "\n\nError: A Sniffles, pbsv, SVIM or cuteSV input is mandatory.\n\n";
 }
 
+my($filename, $dirs, $suffix) = fileparse($output_file, ('.vcf'));
+
 if ($output_file eq "")
 {
     $output_file = "combiSV.vcf";
@@ -110,10 +112,9 @@ if ($output_file eq "")
 }
 else
 {
-    my($filename, $dirs, $suffix) = fileparse($output_file, ('.vcf'));
     $suffix = ".vcf"; 
-    $output_file2 = $dirs.$filename.$suffix;
-    $output_file = $dirs.'simplified_'.$filename.$suffix;  
+    $output_file = $dirs.$filename.$suffix;
+    $output_file2 = $dirs.'simplified_'.$filename.$suffix;  
 }
 
 if ($high_recall eq "")
@@ -2224,32 +2225,32 @@ POS_ALMOST2h:           my $pos_tmp = ($min*$v)+$pos;
     
 #Print SVs------------------------------------------------------------------
 
-my $output_sniffles = "Sniffles_".$output_file2;
+my $output_sniffles = $dir."Sniffles_".$filename;
 if ($input_sniffles ne "")
 {
     open(SNIFFLES, ">" .$output_sniffles) or die "\nCan't open file $output_sniffles, $!\n";
 }
-my $output_pbsv = "pbsv_".$output_file2;
+my $output_pbsv = $dir."pbsv_".$filename;
 if ($input_pbsv ne "")
 {
     open(PBSV, ">" .$output_pbsv) or die "\nCan't open file $output_pbsv, $!\n";
 }
-my $output_nanovar = "NanoVar_".$output_file2;
+my $output_nanovar = $dir."NanoVar_".$filename;
 if ($input_nanovar ne "")
 {
     open(NANOVAR, ">" .$output_nanovar) or die "\nCan't open file $output_nanovar, $!\n";
 }
-my $output_svim = "SVIM_".$output_file2;
+my $output_svim = $dir."SVIM_".$filename;
 if ($input_svim ne "")
 {
     open(SVIM, ">" .$output_svim) or die "\nCan't open file $output_svim, $!\n";
 }
-my $output_nanosv = "NanoSV_".$output_file2;
+my $output_nanosv = $dir."NanoSV_".$filename;
 if ($input_nanosv ne "")
 {
     open(NANOSV, ">" .$output_nanosv) or die "\nCan't open file $output_nanosv, $!\n";
 }
-my $output_cutesv = "cuteSV_".$output_file2;
+my $output_cutesv = $dir."cuteSV_".$filename;
 if ($input_cutesv ne "")
 {
     open(CUTESV, ">" .$output_cutesv) or die "\nCan't open file $output_cutesv, $!\n";

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -2226,32 +2226,32 @@ POS_ALMOST2h:           my $pos_tmp = ($min*$v)+$pos;
     
 #Print SVs------------------------------------------------------------------
 
-my $output_sniffles = $dir."Sniffles_".$filename;
+my $output_sniffles = $dir."Sniffles_".$filename.$suffix;
 if ($input_sniffles ne "")
 {
     open(SNIFFLES, ">" .$output_sniffles) or die "\nCan't open file $output_sniffles, $!\n";
 }
-my $output_pbsv = $dir."pbsv_".$filename;
+my $output_pbsv = $dir."pbsv_".$filename.$suffix;
 if ($input_pbsv ne "")
 {
     open(PBSV, ">" .$output_pbsv) or die "\nCan't open file $output_pbsv, $!\n";
 }
-my $output_nanovar = $dir."NanoVar_".$filename;
+my $output_nanovar = $dir."NanoVar_".$filename.$suffix;
 if ($input_nanovar ne "")
 {
     open(NANOVAR, ">" .$output_nanovar) or die "\nCan't open file $output_nanovar, $!\n";
 }
-my $output_svim = $dir."SVIM_".$filename;
+my $output_svim = $dir."SVIM_".$filename.$suffix;
 if ($input_svim ne "")
 {
     open(SVIM, ">" .$output_svim) or die "\nCan't open file $output_svim, $!\n";
 }
-my $output_nanosv = $dir."NanoSV_".$filename;
+my $output_nanosv = $dir."NanoSV_".$filename.$suffix;
 if ($input_nanosv ne "")
 {
     open(NANOSV, ">" .$output_nanosv) or die "\nCan't open file $output_nanosv, $!\n";
 }
-my $output_cutesv = $dir."cuteSV_".$filename;
+my $output_cutesv = $dir."cuteSV_".$filename.$suffix;
 if ($input_cutesv ne "")
 {
     open(CUTESV, ">" .$output_cutesv) or die "\nCan't open file $output_cutesv, $!\n";

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -9,6 +9,7 @@
 #           nicolasdierckxsens@hotmail.com
 use strict;
 use Getopt::Long;
+use File::Basename;
 
 print "\n\n-----------------------------------------------";
 print "\ncombiSV\n";
@@ -104,19 +105,15 @@ if ($input_sniffles eq "" && $input_cutesv eq "" && $input_pbsv eq "" && $input_
 
 if ($output_file eq "")
 {
-    $output_file = "combiSV";
-    $output_file2 = "simplified_combiSV";
+    $output_file = "combiSV.vcf";
+    $output_file2 = "simplified_combiSV.vcf";
 }
 else
 {
-    $output_file2 = $output_file;
-    $output_file = "simplified_".$output_file2;  
-}
-my $last_four = substr $output_file, -4, 4;
-if ($last_four ne ".vcf")
-{
-    $output_file .= ".vcf";
-    $output_file2 .= ".vcf";
+    my($filename, $dirs, $suffix) = fileparse($output_file);
+    $suffix = ".vcf"; 
+    $output_file = $dirs.$filename.$suffix;
+    $output_file2 = $dirs.'simplified_'.$filename.suffix;  
 }
 
 if ($high_recall eq "")

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -103,7 +103,7 @@ if ($input_sniffles eq "" && $input_cutesv eq "" && $input_pbsv eq "" && $input_
     die "\n\nError: A Sniffles, pbsv, SVIM or cuteSV input is mandatory.\n\n";
 }
 
-my($filename, $dirs, $suffix) = fileparse($output_file, ('.vcf'));
+my($filename, $dir, $suffix) = fileparse($output_file, ('.vcf'));
 
 if ($output_file eq "")
 {
@@ -113,8 +113,8 @@ if ($output_file eq "")
 else
 {
     $suffix = ".vcf"; 
-    $output_file = $dirs.$filename.$suffix;
-    $output_file2 = $dirs.'simplified_'.$filename.$suffix;  
+    $output_file = $dir.$filename.$suffix;
+    $output_file2 = $dir.'simplified_'.$filename.$suffix;  
 }
 
 if ($high_recall eq "")

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -110,10 +110,10 @@ if ($output_file eq "")
 }
 else
 {
-    my($filename, $dirs, $suffix) = fileparse($output_file);
+    my($filename, $dirs, $suffix) = fileparse($output_file, ('.vcf'));
     $suffix = ".vcf"; 
-    $output_file = $dirs.$filename.$suffix;
-    $output_file2 = $dirs.'simplified_'.$filename.$suffix;  
+    $output_file2 = $dirs.$filename.$suffix;
+    $output_file = $dirs.'simplified_'.$filename.$suffix;  
 }
 
 if ($high_recall eq "")

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -109,12 +109,13 @@ if ($output_file eq "")
 {
     $output_file = "combiSV.vcf";
     $output_file2 = "simplified_combiSV.vcf";
+    ($filename, $dir, $suffix) = fileparse($output_file, ('.vcf'));
 }
 else
 {
     $suffix = ".vcf"; 
-    $output_file = $dir.$filename.$suffix;
-    $output_file2 = $dir.'simplified_'.$filename.$suffix;  
+    $output_file2 = $dir.$filename.$suffix;
+    $output_file = $dir.'simplified_'.$filename.$suffix;  
 }
 
 if ($high_recall eq "")

--- a/combiSV2.2.pl
+++ b/combiSV2.2.pl
@@ -113,7 +113,7 @@ else
     my($filename, $dirs, $suffix) = fileparse($output_file);
     $suffix = ".vcf"; 
     $output_file = $dirs.$filename.$suffix;
-    $output_file2 = $dirs.'simplified_'.$filename.suffix;  
+    $output_file2 = $dirs.'simplified_'.$filename.$suffix;  
 }
 
 if ($high_recall eq "")


### PR DESCRIPTION
Fixes #7. Uses File::Parse to parse the output (-o) parameter into $dir, $filename and $suffix. 